### PR TITLE
Tested - update database to add PV potential to homes from spreadsheet.

### DIFF
--- a/update_for_pv_potl.py
+++ b/update_for_pv_potl.py
@@ -11,7 +11,7 @@ import xlrd
 import mysql.connector
 #
 # Open Excel workbook; read sheet into "sheet"
-book = xlrd.open_workbook(r"C:\Documents\Needham\Green Needham\Projects\Solarize Plus\Solarize_assessed_addresses_pct_h.xlsx")
+book = xlrd.open_workbook(r"C:\Documents\Needham\Green Needham\Projects\Solarize Plus\Solarize_assessed_addresses_pct_e.xlsx")
 sheet = book.sheet_by_name("Load")
 #
 # Open MySQL connection 
@@ -45,7 +45,15 @@ for r in range(1, sheet.nrows):
   values = (pv_potl, rs_id)
   print (f" {rs_id} at {st_num} {st_name} has solar potential = {pv_potl} ")
 
-# cursor.execute(update_query, values)
+  try:
+      cursor.execute(update_query, values)
+      database.commit()
+  
+  except mysql.connector.Error as err:
+    print(err)
+    print("Error Code:", err.errno)
+    print("SQLSTATE", err.sqlstate)
+    print("Message", err.msg)
 #
 # Commit changes
 # database.commit()


### PR DESCRIPTION
This version reads a spreadsheet and updates the residence table in the database.  

Each row in the spreadsheet is a residence with PV potential.  The spreadsheet is read and the record in the residence table for that home is updated with the value in the PV potential field.  

This can be used as a template for updating records in a MySQL DB from information in a spreadsheet. 
 (In this case, the original spreadsheet with all the homes in a precinct was downloaded from the database.  Those with PV potential were selected into a new sheet.  That new sheet is the spreadsheet used by this program to update the database.  
